### PR TITLE
Solving EF Core 3.1 Error for Identity

### DIFF
--- a/Entities/User/Role.cs
+++ b/Entities/User/Role.cs
@@ -16,6 +16,7 @@ namespace Entities
     {
         public void Configure(EntityTypeBuilder<Role> builder)
         {
+            builder.Property(p => p.Id).ValueGeneratedOnAdd();
             builder.Property(p => p.Name).IsRequired().HasMaxLength(50);
         }
     }

--- a/Entities/User/User.cs
+++ b/Entities/User/User.cs
@@ -29,6 +29,7 @@ namespace Entities
     {
         public void Configure(EntityTypeBuilder<User> builder)
         {
+            builder.Property(p => p.Id).ValueGeneratedOnAdd();
             builder.Property(p => p.UserName).IsRequired().HasMaxLength(100);
         }
     }


### PR DESCRIPTION
Resolving this error : "UserManager throws exception - Unable to track an entity because primary key property 'Id' is null - after upgrading from .Net Core 2.2 to 3.0"